### PR TITLE
My Youku video was not detected by the regex

### DIFF
--- a/video.php
+++ b/video.php
@@ -49,7 +49,7 @@ class VideoShortCode{
     );
     private $_regexs = array(
         'youku'   => array(
-            'regex' => '/http:\/\/v\.youku\.com\/v_show\/id_(\w+)\.html(\?from=(.*)+)?/',
+            'regex' => '/http:\/\/v\.youku\.com\/v_show\/id_([\w=]+)\.html(\?from=(.*)+)?/',
             'count' => 1,
         ),
         'tudou'   => array(


### PR DESCRIPTION
because it contained a `==` at the end of the video id ...

Example: http://v.youku.com/v_show/id_XMTI1NTMwNDM4OA==.html?from=y1.7-1.2